### PR TITLE
Fix incorrect setup command in Getting Started (intro.md) documentation

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,7 +1,6 @@
 ---
 sidebar_position: 0
 slug: /intro
-
 ---
 
 # Getting Started
@@ -16,7 +15,6 @@ For example, lets say you have a lot of `git` commands you type in during the da
 The binary executable is `cocmd`.
 
 ### Step 1 - Install CoCMD
-
 
 #### Mac - Homebrew
 
@@ -63,14 +61,25 @@ To update, run the same command again.
 
 ### Step 2 - Add CoCMD to your shell
 
-Run in terminal:
+To add CoCMD to your shell, run the appropriate command in your terminal based on your shell:
+
+For Zsh:
 ```shell
-cocmd setup zsh
-or 
-cocmd setup bash
+cocmd setup --shell zsh
 ```
 
-what this does is adding a loader of all aliases and automations shortcuts to your shell and lets you call any of them directly.
+For Bash:
+```shell
+cocmd setup --shell bash
+```
+
+Alternatively, you can simply run:
+```shell
+cocmd setup
+```
+and the setup command will attempt to detect your shell and apply the configuration.
+
+What this does is adding a loader of all aliases and automations shortcuts to your shell and lets you call any of them directly.
 
 ## Add Packages
 


### PR DESCRIPTION
## Summary
This pull request corrects an essential command in the Getting Started guide of the documentation. The previous instructions for adding CoCMD to the user's shell were incorrect, potentially causing confusion for new users setting up CoCMD for the first time.

## Changes
- Corrected the setup command syntax for both `zsh` and `bash` shells in the `intro.md` file.

## Impact
The corrected commands provide clear and accurate steps for users to integrate CoCMD into their shell environment, ensuring a smoother initial experience with our tool.

## Testing
The updated commands have been manually verified to work as expected on both `zsh` and `bash` shells.

## Request for Review
I request a review for this pull request to ensure the documentation reflects the correct usage of our setup commands. This change is crucial as it is part of the initial setup process for new users. Prompt merging of this fix will greatly aid in maintaining a positive first impression of CoCMD.
